### PR TITLE
[riscv] Fix compiler warning in platform.c

### DIFF
--- a/arch/riscv/kernel/platform.c
+++ b/arch/riscv/kernel/platform.c
@@ -14,7 +14,7 @@
 
 /* HACK: Remove all references to Log in code so we can remove this define */
 #ifndef Log
-# define Log
+# define Log(...)
 #endif
 
 static struct resource config_string_resources[] = {


### PR DESCRIPTION
Should have been in previous pull request. Sorry about that.

Proper fix for typo in previous commit:
[riscv] Build fix for leftbehind debug code